### PR TITLE
fix(auth): ensure JWT identity is string and move is_admin to additional_claims

### DIFF
--- a/part2/task_05_review.md
+++ b/part2/task_05_review.md
@@ -54,6 +54,9 @@ These methods manage review creation, retrieval, updates, and deletion. You need
 
 Create the `api/v1/reviews.py` file, then define the routes and create the skeleton methods for these endpoints. Use the placeholders provided below to get started.
 
+> [!IMPORTANT]
+> **The endpoint `GET /api/v1/places/<place_id>/reviews` must be added in `api/v1/places.py` instead of `api/v1/reviews.py`, to keep the correct route under the `places` namespace.**
+
 ```python
 from flask_restx import Namespace, Resource, fields
 from app.services import facade
@@ -108,8 +111,12 @@ class ReviewResource(Resource):
         """Delete a review"""
         # Placeholder for the logic to delete a review
         pass
+```
 
-@api.route('/places/<place_id>/reviews')
+Then, in `api/v1/places.py`, add the following resource to handle reviews of a place:
+
+```python
+@api.route('/<place_id>/reviews')
 class PlaceReviewList(Resource):
     @api.response(200, 'List of reviews for the place retrieved successfully')
     @api.response(404, 'Place not found')
@@ -129,7 +136,7 @@ class PlaceReviewList(Resource):
 **Explanation:**
 
 - The `POST` endpoint handles the creation of a new review, while `GET`, `PUT`, and `DELETE` endpoints manage review retrieval, updates, and deletion.
-- The `GET /api/v1/places/<place_id>/reviews` endpoint is specific to retrieving all reviews associated with a particular place.
+- The `GET /api/v1/places/<place_id>/reviews` endpoint is defined in the `places.py` file, under the `places` namespace, to avoid confusing route paths.
 - Placeholders are provided, but you need to implement the logic that handles relationships between reviews, users, and places.
 
 > [!IMPORTANT]
@@ -170,8 +177,8 @@ For each endpoint, ensure that the input format, output format, and status codes
 ### Test the Provided Endpoints
 
 Once the endpoints are implemented, use tools like Postman or cURL to test each operation.
-Ensure that your endpoints are working as expected. Here are some examples:
-
+Ensure that your endpoints are working as expected.
+examples:
 #### Register a New Review (POST /api/v1/reviews/)
 
 ```http

--- a/part3/task_02_jwt.md
+++ b/part3/task_02_jwt.md
@@ -129,7 +129,10 @@ This sequence diagram visualizes the flow where:
                  return {'error': 'Invalid credentials'}, 401
 
              # Step 3: Create a JWT token with the user's id and is_admin flag
-             access_token = create_access_token(identity={'id': str(user.id), 'is_admin': user.is_admin})
+             access_token = create_access_token(
+             identity=str(user.id),   # only user ID goes here
+             additional_claims={"is_admin": user.is_admin}  # extra info here
+             )
              
              # Step 4: Return the JWT token to the client
              return {'access_token': access_token}, 200
@@ -151,14 +154,18 @@ This sequence diagram visualizes the flow where:
    Example:
    ```python
    from flask_jwt_extended import jwt_required, get_jwt_identity
-
    @api.route('/protected')
    class ProtectedResource(Resource):
        @jwt_required()
        def get(self):
-           """A protected endpoint that requires a valid JWT token"""
-           current_user = get_jwt_identity()  # Retrieve the user's identity from the token
-           return {'message': f'Hello, user {current_user["id"]}'}, 200
+            """A protected endpoint that requires a valid JWT token"""
+            print("jwt------")
+            print(get_jwt_identity())
+            current_user = get_jwt_identity() # Retrieve the user's identity from the token
+            #if you need to see if the user is an admin or not, you can access additional claims using get_jwt() :
+            # addtional claims = get_jwt()
+            #additional claims["is_admin"] -> True or False
+            return {'message': f'Hello, user {current_user}'}, 200
    ```
 
    **Explanation:**


### PR DESCRIPTION
### Context  
The JWT task in the hbnb doc was outdated and caused the error **"Subject must be a string"** because a dictionary was passed as `identity`.  

### Fix  
Now only the `user.id` (string) is used as `identity`, and `is_admin` is moved to `additional_claims` to match the latest `flask-jwt-extended` requirements. 